### PR TITLE
version fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,8 +68,8 @@
   "homepage": "https://github.com/Paratii-Video/paratii-mediaplayer#readme",
   "peerDependencies": {
     "clappr": "^0.2.78",
-    "hlsjs-ipfs-loader": "^0.1.2",
-    "ipfs": "^0.27.7",
+    "hlsjs-ipfs-loader": "github:ya7ya/hlsjs-ipfs-loader#bd890b9e78f2c273fcb1dc4e1d43ad0afc69558c",
+    "ipfs": "github:Paratii-Video/js-ipfs#paratii/v0.28.2",
     "ipfs-bitswap": "^0.19.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",


### PR DESCRIPTION
this fixes the `hlsjs-ipfs-loader` and `ipfs` versions. 